### PR TITLE
Add RSS Link to header

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,9 @@
 {{ range .AllTranslations }}
   <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}">
 {{ end }}
-
+{{ range .AlternativeOutputFormats -}}
+<link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
+{{ end -}}
 
 <meta itemprop="image" content="{{ .Site.Params.ogimage | absURL }}" />
 <meta property="og:image" content="{{ .Site.Params.ogimage | absURL }}" />


### PR DESCRIPTION
Add the link to the existing RSS feed (which is at https://plan4better.de/blog/index.xml) to the head so RSS reader can discover it.

Added code based on a mix of https://forestry.io/docs/guides/developing-with-hugo/misc/#rss-feeds (which did not work out of the box) and https://pakstech.com/blog/hugo-rss/.

The rss feed does not show the blogpost author and only the summary, not the full content. But the template comes from forestry.io and I could not figure out who to overwrite/customize it.